### PR TITLE
Fixes coverage definition in package.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,12 +54,22 @@ find more details switching to the [Foo Number Format Library Example][] or
 ### Locale coverage
 
 By default, the locale coverage installed is `core`, which Unicode defines as
-the top tier languages and is equivalent to the `json.zip` content. If you need
-full locale coverage, use `CLDR_COVERAGE` environment variable to modify the
-installation behavior. For example:
+the top tier languages and is equivalent to the `json.zip` content. There exists two solutions to get the full coverage: either by setting the environmental variable `CLDR_COVERAGE` to `full` or define the coverage in your `package.json`.
 
+#### Environmental variable
+In this example we are installing `cldr-data` by setting the `CLDR_COVERAGE` to `full`:
 ```
 $ CLDR_COVERAGE=full npm install
+```
+
+#### package.json
+Define your coverage by setting the property `cldr-data-coverage` in your `package.json:
+```
+{
+	...
+	"cldr-data-coverage": "full",
+	...
+}
 ```
 
 ## License

--- a/install.js
+++ b/install.js
@@ -11,8 +11,24 @@
 var cldrDownloader = require("cldr-data-downloader");
 var path = require("path");
 var urls = require("./urls");
+var parentPackage;
+var url;
 
-var url = urls[process.env.CLDR_COVERAGE || "core"];
+try {
+  parentPackage = require('../../package.json');
+}
+catch(error) {}
+
+url = urls[process.env.CLDR_COVERAGE || "core"];
+
+if (parentPackage) {
+  if (parentPackage["cldr-data-coverage"] && parentPackage.dependencies["cldr-data"]) {
+    if (!/^full|core$/.test(parentPackage["cldr-data-coverage"])) {
+      throw new TypeError("Your `cldr-data-coverage setting must have the value \"core\" or \"full\".");
+    }
+    url = urls[parentPackage["cldr-data-coverage"]];
+  }
+}
 
 if (process.env.CLDR_URL) {
   url = url.replace(


### PR DESCRIPTION
This change makes defining coverage in a parent `package.json` available. No environmental variable needed. It works as specified in #6. It only look at the coverage in `package.json` if and only if `cldr-data` is defined in `dependencies`.