### PR TITLE
install: Fix detection of npm@3 on node@0.10

### DIFF
--- a/install.js
+++ b/install.js
@@ -22,8 +22,18 @@ try {
   var npmv = child_process.execSync('npm -v').toString('utf8');
   isNpm3 = (npmv.split('.')[0] == '3');
 } catch(error) {
-  // Better safe than sorry.
-  isNpm3 = true;
+  // child_process.execSync is not available on Node v0.10
+  // fortunately, we can use ENV variables set by npm do detect its version
+  //   npm_config_user_agent: 'npm/2.15.1 node/v0.10.46 darwin x64'
+  //   npm_config_user_agent: 'npm/3.10.3 node/v6.3.0 darwin x64'
+  // Note that users can override the value of this config option,
+  // therefore it's safer to use this method only as a fall-back option.
+  if (/^npm\/2\./.test(process.env.npm_config_user_agent)) {
+    isNpm3 = false;
+  } else {
+    // Better safe than sorry.
+    isNpm3 = true;
+  }
 }
 
 try {


### PR DESCRIPTION
The `install` script uses `child_process.execSync` to detect npm version. This API was added in Node v0.12 and is not available in Node v0.10. As a result, the script always download CLDR data, even when this package was not explicitly listed in project dependencies.

This commit fixes the problem by using `npm_config_user_agent` as a fallback mechanism. 

Related: https://github.com/strongloop/strong-globalize/issues/58

@rxaviers PTAL
