### PR TITLE
Allow filter downloads via 'cldr-data-urls-filter' property in package.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,10 +88,10 @@ On the `package.json` of you application, set the locale coverage using the
 }
 ```
 
-#### Set Custom json file with urls
+#### Set Custom json file with urls or filter existing
 
-By default, used file `urls.json` form cldr-data module, which contain 
-for each lovale coverage 18 urls. For set custom `.json` file, that have 
+By default, used file `urls.json` form cldr-data module, which contain
+for each lovale coverage 18 urls. For set custom `.json` file, that have
 structure accoding `urls.json` use `cldr-data-urls-json` property in `package.json` your webApp
 *Define the package.json `cldr-data-urls-json` property*
 
@@ -105,7 +105,7 @@ structure accoding `urls.json` use `cldr-data-urls-json` property in `package.js
 Path must be relative from cldr-data directory
 
 
-*Example custom cldrdatadwnl.json* 
+*Example custom cldrdatadwnl.json*
 File have only 7 urls.
 ```
 {
@@ -120,6 +120,18 @@ File have only 7 urls.
     ]
 }
 ```
+
+Or you can filter existing urls by regexp pattern, via `cldr-data-urls-filter`
+field in `package.json`:
+
+```
+{
+  ...
+  "cldr-data-urls-filter": "(cldr-core|cldr-numbers-modern|cldr-dates-modern)",
+  ...
+}
+```
+
 
 ## License
 

--- a/install.js
+++ b/install.js
@@ -97,6 +97,10 @@ if (process.env.CLDR_URL) {
     coverage = parentPackage["cldr-data-coverage"];
   }
 
+  if (parentPackage && parentPackage["cldr-data-urls-filter"]) {
+    options.filterRe = parentPackage["cldr-data-urls-filter"];
+  }
+
   if (coverage) {
     options.srcUrlKey = coverage;
   }

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "test": "grunt && node test/index.js"
   },
   "dependencies": {
-    "cldr-data-downloader": "0.2.x",
+    "cldr-data-downloader": "0.3.x",
     "glob": "5.x.x"
   },
   "devDependencies": {


### PR DESCRIPTION
close #44

PS. At least it showed reduced files list as expected, but failed to download due missed files for 31.0.0