### PR TITLE
chore: fix package.json license property

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "type": "git",
     "url": "git://github.com/rxaviers/cldr-data-npm.git"
   },
-  "licenses": [
+  "license": [
     {
       "type": "MIT",
       "url": "https://github.com/rxaviers/cldr-data-npm/blob/master/LICENSE"


### PR DESCRIPTION
## Goal

Fix license property name to allow for automatic license discovery. Currently, license shows as `none` on npmjs.com. This makes it difficult to consume this library as we can't automatically discover the license based on npm metadata.

Screenshot illustrating the npm UI showing `none` for license:
![image](https://user-images.githubusercontent.com/2252976/69503871-01d75900-0ed3-11ea-91b2-28302036b342.png)


## Changes

- Change `licenses` to `license` per the npm documentation: https://docs.npmjs.com/files/package.json#license

## Notes

- I did not open an issue to discuss this change because it is a trivial single character change.
- Thanks for providing this library!