### PR TITLE
Version bump for adm-zip security vulnerability

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cldr-data",
-  "version": "36.0.0",
+  "version": "36.0.1",
   "keywords": [
     "unicode",
     "CLDR",
@@ -36,7 +36,7 @@
     "test": "grunt && node test/index.js"
   },
   "dependencies": {
-    "cldr-data-downloader": "0.3.x",
+    "cldr-data-downloader": "1.0.0-1",
     "glob": "5.x.x"
   },
   "devDependencies": {


### PR DESCRIPTION
Package updated adm-zip under the cldr-data-downloader and updating the package under cldr-data-npm to address security vulnerability Link : https://github.com/rxaviers/cldr-data-downloader/commit/3b3b9675a6aac2736c596513c7a756086bca5413